### PR TITLE
fix: Checkout main before updating readme

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: 'The release configuration to use for the release. Set this to `@catalystsquad/release-config-javascript-actions` for javascript actions'
     required: false
     default: '@catalystsquad/release-config-composite-actions'
+  main-branch-name:
+    description: 'Branch to update the readme on'
+    required: false
+    default: main
 runs:
   using: composite
   steps:
@@ -33,7 +37,12 @@ runs:
       with:
         semantic_version: 18 # newest version has issues with actions and I haven't figured out why yet
         extends: ${{ inputs.release-config }}
-    - name: Update Readme
+    - name: Checkout main
+      uses: actions/checkout@v2
+      with:
+        token: ${{ inputs.token }}
+        ref: ${{ inputs.main-branch-name }}
+    - name: Update Readme 
       uses: bitflight-devops/github-action-readme-generator@v1.0.12a
       with:
         action: ${{ github.workspace }}/action.yaml


### PR DESCRIPTION
Readme update failed because the ref is the PR source branch, not main, so when the readme is updated the branch doesn't exist.