### PR TITLE
fix: Specify which branch to commit readme back to. "main" is already…

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,12 +37,7 @@ runs:
       with:
         semantic_version: 18 # newest version has issues with actions and I haven't figured out why yet
         extends: ${{ inputs.release-config }}
-    - name: Checkout main
-      uses: actions/checkout@v2
-      with:
-        token: ${{ inputs.token }}
-        ref: ${{ inputs.main-branch-name }}
-    - name: Update Readme 
+    - name: Update Readme
       uses: bitflight-devops/github-action-readme-generator@v1.0.12a
       with:
         action: ${{ github.workspace }}/action.yaml
@@ -53,6 +48,8 @@ runs:
         version_override: v${{ steps.semantic-release.outputs.new_release_major_version }}
     - name: Commit Readme Changes
       uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        branch: ${{ inputs.main-branch-name }}
     - name: Re-enable include admins
       uses: catalystsquad/action-branch-protection-bot@v1
       if: inputs.toggle-admins == 'true' && always()  # Force to always run this step to ensure "include administrators" is always turned back on


### PR DESCRIPTION
… checked out when this workflow runs, but the auto commit action defaults to head_ref so for PR triggers you must specify the branch name.